### PR TITLE
Address warning in build system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,12 +12,13 @@ include(FetchContent)
 FetchContent_Declare(
         googletest
         GIT_REPOSITORY https://github.com/google/googletest.git
-        GIT_TAG v1.15.2)
-FetchContent_Declare(asio
+        GIT_TAG v1.15.2
+        GIT_SHALLOW TRUE)
+FetchContent_Declare(
+        asio
         GIT_REPOSITORY https://github.com/chriskohlhoff/asio.git
         GIT_TAG asio-1-32-0
-        CONFIGURE_COMMAND ""
-        BUILD_COMMAND "")
+        GIT_SHALLOW TRUE)
 FetchContent_Declare(
         nanobench
         GIT_REPOSITORY https://github.com/martinus/nanobench.git


### PR DESCRIPTION
Addresses cmake warnings about configuration being unset, rather than set to the empty string.